### PR TITLE
Costumes/Stories style fix

### DIFF
--- a/client/src/components/Costumes-components/CostumesList.tsx
+++ b/client/src/components/Costumes-components/CostumesList.tsx
@@ -26,42 +26,24 @@ const CostumesList = () => {
 
   return (
     <>
-      <div className="d-flex justify-content-center" style={{ height: "40px" }}>
-        <button
-          className={`btn btn-outline-danger tab ${select && "active"} `}
-          onClick={() => switchDisplay()}
-        >
+    <div className="">
+      <div className="d-inline-flex justify-content-left" style={{ height: "40px" }}>
+        <button className={`btn btn-outline-danger tab ${select && "active"} `} onClick={() => {if(!select){switchDisplay()}}} style={{borderTopRightRadius: '0%', borderBottomRightRadius: '0%'}}>
           Mens
         </button>
-        <button
-          className={`btn btn-outline-danger tab ${!select && "active"} `}
-          onClick={() => switchDisplay()}
-        >
+        <button className={`btn btn-outline-danger tab ${!select && "active"} `} onClick={() => {if(select){switchDisplay()}}} style={{borderTopLeftRadius: '0%', borderBottomLeftRadius: '0%'}}>
           Womens
         </button>
       </div>
-      <div
-        className="d-flex justify-content-center mt-3"
-        style={{ height: "40px" }}
-      >
-        <button
-          className={`btn btn-outline-danger`}
-          onClick={() => switchPage(-1)}
-          disabled={index === 0}
-        >
+      <div className="d-inline-flex justify-content-right" style={{ height: "40px", float: 'right', }}>
+        <button className={`btn btn-outline-danger`} onClick={() => switchPage(-1)} disabled={index === 0} style={{borderTopRightRadius: '0%', borderBottomRightRadius: '0%'}}>
           <i className="fa-solid fa-chevron-left"></i>Prev
         </button>
-        <button
-          className={`btn btn-outline-danger `}
-          onClick={() => switchPage(1)}
-          disabled={
-            index + listLength >=
-            (select ? mens_selection.length : womens_selection.length)
-          }
-        >
+        <button className={`btn btn-outline-danger `} onClick={() => switchPage(1)} disabled={ index + listLength >= (select ? mens_selection.length : womens_selection.length) } style={{borderTopLeftRadius: '0%', borderBottomLeftRadius: '0%'}}>
           Next <i className="fa-solid fa-chevron-right"></i>
         </button>
       </div>
+    </div>
 
       <div className="container mt-5">
         <div className="row">

--- a/client/src/components/Stories-components/Stories.tsx
+++ b/client/src/components/Stories-components/Stories.tsx
@@ -15,7 +15,7 @@ const StoriesPage = () => {
     const currentUser = useSelector(selectCurrentUser);
     const [view, setView] = useState('storyList');
     const [allStories, setAllStories] = useState([]);
-    const [selectedStory, setSelected] = useState({createdAt: '', id: '', images: '', title: '', story: '', description: '', author:{name:''}, likedBy:[],});
+    const [selectedStory, setSelected] = useState({createdAt: '', id: '', images: '', title: '', story: '', description: '', author:{name:''}, likedBy:[], Comment:[]});
     const [isLoading, setIsLoading] = useState(true);
 
     //get stories from database
@@ -50,7 +50,7 @@ const StoriesPage = () => {
 
             {view === 'storyList' && !allStories.length && <div>Loading...</div>}
             <>
-            {view === 'storyList' && allStories.map(((story:{authorId:String, createdAt:String, id:String, images:any, title:String, story:String, description?:String}, index:any) => {
+            {view === 'storyList' && allStories.map(((story:{authorId:String, createdAt:String, id:String, images:any, title:String, story:String, description?:String, author:{name:string}, likedBy:any, Comment: any}, index:any) => {
                 return <div key={index}>
                         <Story test={viewHandler} story={story} key={index} />
                         <br style={{margin: 5}}></br>

--- a/client/src/components/Stories-components/Stories.tsx
+++ b/client/src/components/Stories-components/Stories.tsx
@@ -45,8 +45,8 @@ const StoriesPage = () => {
     }
 
     return (
-        <div id="stories_page">
-            {view === 'storyList' && <button onClick={() => viewHandler('write', null)} className="btn btn-danger">Write a Story</button>}
+        <div id="stories_page" style={{color: 'white'}}>
+            {view === 'storyList' && <button onClick={() => viewHandler('write', null)} className="btn btn-danger" style={{color: 'white', marginBottom: 5}}>Write a Story</button>}
 
             {view === 'storyList' && !allStories.length && <div>Loading...</div>}
             <>

--- a/client/src/components/Stories-components/Stories.tsx
+++ b/client/src/components/Stories-components/Stories.tsx
@@ -45,7 +45,7 @@ const StoriesPage = () => {
     }
 
     return (
-        <div id="stories_page" style={{color: 'white'}}>
+        <div id="stories_page" style={{color: view !== 'write' ? 'white' : 'black'}}>
             {view === 'storyList' && <button onClick={() => viewHandler('write', null)} className="btn btn-danger" style={{color: 'white', marginBottom: 5}}>Write a Story</button>}
 
             {view === 'storyList' && !allStories.length && <div>Loading...</div>}

--- a/client/src/components/Stories-components/Story.tsx
+++ b/client/src/components/Stories-components/Story.tsx
@@ -6,12 +6,14 @@ const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any,
     const HauntedHouse = require('../../../../assets/haunted-house.jpg').default;
 
     return (
-        <div className="card single_post">
+    <div className="card single_post">
+        <div className="top">
+            <h3 style={{marginTop: 5, display: 'flex', justifyContent: 'center', alignItems: 'center'}}><b onClick={() => props.test('story', props.story)} style={{cursor: 'pointer',}}><u>{props.story.title}</u></b></h3>
+        </div>
         <div className="body">
             <div className="img-post">
-                <img className="d-block img-fluid" src={props.story.images ? props.story.images : HauntedHouse}  alt="First slide"/>
+                <img className="d-block img-fluid" onClick={() => props.test('story', props.story)} style={{cursor: 'pointer'}} src={props.story.images ? props.story.images : HauntedHouse}  alt="First slide"/>
             </div>
-            <h3><b onClick={() => props.test('story', props.story)}>{props.story.title}</b></h3>
             <p> {props.story.description ? props.story.description : props.story.story.slice(0, 100) + '...'}</p>
         </div>
         <div className="footer">
@@ -24,7 +26,6 @@ const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any,
             </ul>
         </div>
     </div>
-
     )
 }
 

--- a/client/src/components/Stories-components/Story.tsx
+++ b/client/src/components/Stories-components/Story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { textSpanContainsPosition } from 'typescript';
-import "./stories.styles.css";
+import "./story.styles.css";
 
 const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any, title:String, story:String, description?: String, author: {name: string}, likedBy: any, Comment: any}, key:any }) => {
     const HauntedHouse = require('../../../../assets/haunted-house.jpg').default;

--- a/client/src/components/Stories-components/Story.tsx
+++ b/client/src/components/Stories-components/Story.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { textSpanContainsPosition } from 'typescript';
 import "./stories.styles.css";
 
-const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any, title:String, story:String, description?: String}, key:any }) => {
+const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any, title:String, story:String, description?: String, author: {name: string}, likedBy: any, Comment: any}, key:any }) => {
     const HauntedHouse = require('../../../../assets/haunted-house.jpg').default;
 
     return (
@@ -11,7 +11,7 @@ const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any,
             <div className="img-post">
                 <img className="d-block img-fluid" src={props.story.images ? props.story.images : HauntedHouse}  alt="First slide"/>
             </div>
-            <h3><a href="blog-details.html">{props.story.title}</a></h3>
+            <h3><b onClick={() => props.test('story', props.story)}>{props.story.title}</b></h3>
             <p> {props.story.description ? props.story.description : props.story.story.slice(0, 100) + '...'}</p>
         </div>
         <div className="footer">
@@ -19,8 +19,8 @@ const Story = (props:{ test:any, story:{createdAt:String, id:String, images:any,
                 <span onClick={() => props.test('story', props.story)} className="btn btn-outline-secondary">Continue Reading</span>
             </div>
             <ul className="stats">
-                <li><a href="#" className="fa fa-heart">5</a></li>
-                <li><a href="#" className="fa fa-comment">10</a></li>
+                <li><a href="#" className="fa fa-heart">{props.story.likedBy.length}</a></li>
+                <li><a href="#" className="fa fa-comment">{props.story.Comment.length}</a></li>
             </ul>
         </div>
     </div>

--- a/client/src/components/Stories-components/StoryDisplay.tsx
+++ b/client/src/components/Stories-components/StoryDisplay.tsx
@@ -115,15 +115,15 @@ const StoryDisplay = (props: {
   };
 
   return (
-    <div className="row" style={{ background: "rgb(220, 53, 69)", display: "flex", justifyContent: "center", alignItems: "center", }}>
+    <div className="row" style={{ background: "black", display: "flex", justifyContent: "center", alignItems: "center", }}>
       <div className="text-left" style={{ display: "inline-block", width: isEditing || !sameUser ? "100%" : "50%", }}>
-        <button onClick={() => { !isEditing ? props.backHandler("storyList") : backToDisplayHandler(); }} style={{ minWidth: 100, display: "inline-block", background: "black", color: "lime", borderRadius: "45%", float: "left", }}>
+        <button className="btn btn-outline-secondary" onClick={() => { !isEditing ? props.backHandler("storyList") : backToDisplayHandler(); }} style={{ minWidth: 100, display: "inline-block", float: "left", }}>
           Back
         </button>
       </div>
       {(currentUser ? currentUser.name : false) === props.story.author.name && !isEditing && (
           <div className="text-right" style={{ display: "inline-block", width: "50%" }}>
-            <button style={{ minWidth: 100, background: "black", color: "lime", borderRadius: "45%", float: "right", }} onClick={() => setIsEditing(!isEditing)}>
+            <button className="btn btn-outline-secondary" style={{ minWidth: 100, float: "right", }} onClick={() => setIsEditing(!isEditing)}>
               edit
             </button>
           </div>
@@ -158,7 +158,7 @@ const StoryDisplay = (props: {
             })}
           </div>
           {currentUser && (
-            <button onClick={likeButtonHandler} style={{ maxWidth: 150, borderRadius: 50, background: "black", color: "lime", }}>
+            <button className="btn btn-outline-secondary" onClick={likeButtonHandler} style={{ maxWidth: 150, borderRadius: 50, }}>
               {isLiked ? "Unlike" : "Like"}
             </button>
           )}
@@ -171,24 +171,24 @@ const StoryDisplay = (props: {
               <u>{title}</u>
             </b>
           </h5>
-          <textarea placeholder="description text" rows={3} value={description?.toString()} onChange={editDescriptionInputHandler} style={{ borderColor: description.length > 300 ? "red" : "" }}>
+          <textarea placeholder="description text" rows={3} value={description?.toString()} onChange={editDescriptionInputHandler} style={{ borderColor: description.length > 300 ? "red" : "", margin: 5, color: 'black', }}>
           </textarea>
           <p>
             {description.length > 300 ? `You are ${description.length - 300} characters over the limit!` : ""}
           </p>
-          <textarea placeholder="story text" rows={5} value={story.toString()} onChange={editStoryInputHandler} style={{ borderColor: story.length > 10000 ? "red" : "" }}>
+          <textarea placeholder="story text" rows={5} value={story.toString()} onChange={editStoryInputHandler} style={{ borderColor: story.length > 10000 ? "red" : "", margin: 5, color: 'black', }}>
           </textarea>
           <p>
             {story.length > 10000 ? `You are ${story.length - 10000} characters over the limit!` : ""}
           </p>
-          <input placeholder="image url" value={image} onChange={editImageInputHandler} style={{ marginBottom: 5 }}>
+          <input placeholder="image url" value={image} onChange={editImageInputHandler} style={{ margin: 5, color: 'black', }}>
           </input>
           {image ? (
             <img src={image} style={{ maxWidth: "100px", maxHeight: "100px" }}>
             </img>
           ) : ( <div></div> )}
           <div>{editClicked ? "saving changes..." : ""}</div>
-          <button disabled={editClicked} onClick={editButtonHandler} style={{ maxWidth: 150, borderRadius: "45%", background: "black", color: "lime", }}>
+          <button className="btn btn-outline-secondary" disabled={editClicked} onClick={editButtonHandler} style={{ maxWidth: 150, margin: 5, }}>
             Save Changes
           </button>
         </>

--- a/client/src/components/Stories-components/StoryDisplay.tsx
+++ b/client/src/components/Stories-components/StoryDisplay.tsx
@@ -115,60 +115,19 @@ const StoryDisplay = (props: {
   };
 
   return (
-    <div
-      className="row"
-      style={{
-        background: "rgb(220, 53, 69)",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <div
-        className="text-left"
-        style={{
-          display: "inline-block",
-          width: isEditing || !sameUser ? "100%" : "50%",
-        }}
-      >
-        <button
-          onClick={() => {
-            !isEditing
-              ? props.backHandler("storyList")
-              : backToDisplayHandler();
-          }}
-          style={{
-            minWidth: 100,
-            display: "inline-block",
-            background: "black",
-            color: "lime",
-            borderRadius: "45%",
-            float: "left",
-          }}
-        >
+    <div className="row" style={{ background: "rgb(220, 53, 69)", display: "flex", justifyContent: "center", alignItems: "center", }}>
+      <div className="text-left" style={{ display: "inline-block", width: isEditing || !sameUser ? "100%" : "50%", }}>
+        <button onClick={() => { !isEditing ? props.backHandler("storyList") : backToDisplayHandler(); }} style={{ minWidth: 100, display: "inline-block", background: "black", color: "lime", borderRadius: "45%", float: "left", }}>
           Back
         </button>
       </div>
-      {(currentUser ? currentUser.name : false) === props.story.author.name &&
-        !isEditing && (
-          <div
-            className="text-right"
-            style={{ display: "inline-block", width: "50%" }}
-          >
-            <button
-              style={{
-                minWidth: 100,
-                background: "black",
-                color: "lime",
-                borderRadius: "45%",
-                float: "right",
-              }}
-              onClick={() => setIsEditing(!isEditing)}
-            >
+      {(currentUser ? currentUser.name : false) === props.story.author.name && !isEditing && (
+          <div className="text-right" style={{ display: "inline-block", width: "50%" }}>
+            <button style={{ minWidth: 100, background: "black", color: "lime", borderRadius: "45%", float: "right", }} onClick={() => setIsEditing(!isEditing)}>
               edit
             </button>
           </div>
-        )}
+      )}
       {!isEditing && (
         <>
           <h5 style={{ display: "flex", justifyContent: "center" }}>
@@ -176,16 +135,10 @@ const StoryDisplay = (props: {
               <u>{title}</u>
             </b>
           </h5>
-          <div
-            className="col-6"
-            style={{ display: "flex", justifyContent: "left" }}
-          >
+          <div className="col-6" style={{ display: "flex", justifyContent: "left" }}>
             by: {username}
           </div>
-          <div
-            className="col-6"
-            style={{ display: "flex", justifyContent: "right" }}
-          >
+          <div className="col-6" style={{ display: "flex", justifyContent: "right" }}>
             published:{" "}
             {props.story.createdAt.slice(0, props.story.createdAt.indexOf("T"))}
           </div>
@@ -193,14 +146,9 @@ const StoryDisplay = (props: {
             {numLikes} Like{numLikes > 1 || numLikes === 0 ? "s" : ""}
           </div>
           <Voice text={story.toString()}></Voice>
-          <img
-            src={props.story.images ? props.story.images : HauntedHouse}
-            style={{ maxWidth: 450, maxHeight: 450 }}
-          ></img>
-          <div
-            className="row"
-            style={{ display: "flex", justifyContent: "left" }}
-          >
+          <img src={props.story.images ? props.story.images : HauntedHouse} style={{ maxWidth: 450, maxHeight: 450 }}>
+          </img>
+          <div className="row" style={{ display: "flex", justifyContent: "left" }}>
             {story.split("\n").map((paragraph: string, index: number) => {
               return (
                 <p className="col-12" key={index}>
@@ -210,15 +158,7 @@ const StoryDisplay = (props: {
             })}
           </div>
           {currentUser && (
-            <button
-              onClick={likeButtonHandler}
-              style={{
-                maxWidth: 150,
-                borderRadius: 50,
-                background: "black",
-                color: "lime",
-              }}
-            >
+            <button onClick={likeButtonHandler} style={{ maxWidth: 150, borderRadius: 50, background: "black", color: "lime", }}>
               {isLiked ? "Unlike" : "Like"}
             </button>
           )}
@@ -231,55 +171,24 @@ const StoryDisplay = (props: {
               <u>{title}</u>
             </b>
           </h5>
-          <textarea
-            placeholder="description text"
-            rows={3}
-            value={description?.toString()}
-            onChange={editDescriptionInputHandler}
-            style={{ borderColor: description.length > 300 ? "red" : "" }}
-          ></textarea>
+          <textarea placeholder="description text" rows={3} value={description?.toString()} onChange={editDescriptionInputHandler} style={{ borderColor: description.length > 300 ? "red" : "" }}>
+          </textarea>
           <p>
-            {description.length > 300
-              ? `You are ${description.length - 300} characters over the limit!`
-              : ""}
+            {description.length > 300 ? `You are ${description.length - 300} characters over the limit!` : ""}
           </p>
-          <textarea
-            placeholder="story text"
-            rows={5}
-            value={story.toString()}
-            onChange={editStoryInputHandler}
-            style={{ borderColor: story.length > 10000 ? "red" : "" }}
-          ></textarea>
+          <textarea placeholder="story text" rows={5} value={story.toString()} onChange={editStoryInputHandler} style={{ borderColor: story.length > 10000 ? "red" : "" }}>
+          </textarea>
           <p>
-            {story.length > 10000
-              ? `You are ${story.length - 10000} characters over the limit!`
-              : ""}
+            {story.length > 10000 ? `You are ${story.length - 10000} characters over the limit!` : ""}
           </p>
-          <input
-            placeholder="image url"
-            value={image}
-            onChange={editImageInputHandler}
-            style={{ marginBottom: 5 }}
-          ></input>
+          <input placeholder="image url" value={image} onChange={editImageInputHandler} style={{ marginBottom: 5 }}>
+          </input>
           {image ? (
-            <img
-              src={image}
-              style={{ maxWidth: "100px", maxHeight: "100px" }}
-            ></img>
-          ) : (
-            <div></div>
-          )}
+            <img src={image} style={{ maxWidth: "100px", maxHeight: "100px" }}>
+            </img>
+          ) : ( <div></div> )}
           <div>{editClicked ? "saving changes..." : ""}</div>
-          <button
-            disabled={editClicked}
-            onClick={editButtonHandler}
-            style={{
-              maxWidth: 150,
-              borderRadius: "45%",
-              background: "black",
-              color: "lime",
-            }}
-          >
+          <button disabled={editClicked} onClick={editButtonHandler} style={{ maxWidth: 150, borderRadius: "45%", background: "black", color: "lime", }}>
             Save Changes
           </button>
         </>

--- a/client/src/components/Stories-components/WriteStory.tsx
+++ b/client/src/components/Stories-components/WriteStory.tsx
@@ -62,14 +62,14 @@ const WriteStory = (props:{backHandler: Function}) => {
             <button className="btn btn-outline-secondary" onClick={() => props.backHandler('storyList')} style={{marginBottom: 5}}>Back</button>
             <br style={{margin: 5}}></br>
             <input placeholder='Write your title here...' onChange={titleHandler} value={title} style={{width: '100%', display: 'block', marginBottom: 5, borderColor: title.length > 3000 ? 'red' : ''}}></input>
-            <p>{title.length > 3000 ? `You are ${title.length - 3000} characters over the limit!` : ''}</p>
+            <p style={{color: 'white'}}>{title.length > 3000 ? `You are ${title.length - 3000} characters over the limit!` : ''}</p>
             <textarea rows={3} placeholder="Write your description here..." onChange={descriptionHandler} value={desc} style={{width: '100%', display: 'block', marginBottom: 5, borderColor: desc.length > 300 ? 'red' : ''}}></textarea>
-            <p>{desc.length > 300 ? `You are ${desc.length - 300} characters over the limit!` : ''}</p>
+            <p style={{color: 'white'}}>{desc.length > 300 ? `You are ${desc.length - 300} characters over the limit!` : ''}</p>
             <textarea rows={5} placeholder='Write your story here...' onChange={textHandler} value={text} style={{width: '100%', display: 'block', marginBottom: 5, borderColor: text.length > 10000 ? 'red' : ''}}></textarea>
-            <p>{text.length > 10000 ? `You are ${text.length - 10000} characters over the limit!` : ''}</p>
+            <p style={{color: 'white'}}>{text.length > 10000 ? `You are ${text.length - 10000} characters over the limit!` : ''}</p>
             <input placeholder='Put image link here...' onChange={imageHandler} value={image} style={{width: '100%', display: 'block', marginBottom: 5}}></input>
             {image ? <img src={image} style={{maxWidth: '100px', maxHeight: '100px'}}></img> : <div></div>}
-            <p><b>{formFilled}</b></p>
+            <p style={{color: 'white'}}><b>{formFilled}</b></p>
             <button className="btn btn-outline-secondary" disabled={isLoading} onClick={postHandler} style={{minWidth: 50}}>Post</button>
         </div>
     )

--- a/client/src/components/Stories-components/WriteStory.tsx
+++ b/client/src/components/Stories-components/WriteStory.tsx
@@ -59,7 +59,7 @@ const WriteStory = (props:{backHandler: Function}) => {
 
     return (
         <div id='write_story'>
-            <button onClick={() => props.backHandler('storyList')} style={{background: 'black', color: 'lime', borderRadius: '45%', minWidth: 50, marginBottom: 5}}>Back</button>
+            <button className="btn btn-outline-secondary" onClick={() => props.backHandler('storyList')} style={{marginBottom: 5}}>Back</button>
             <br style={{margin: 5}}></br>
             <input placeholder='Write your title here...' onChange={titleHandler} value={title} style={{width: '100%', display: 'block', marginBottom: 5, borderColor: title.length > 3000 ? 'red' : ''}}></input>
             <p>{title.length > 3000 ? `You are ${title.length - 3000} characters over the limit!` : ''}</p>
@@ -70,7 +70,7 @@ const WriteStory = (props:{backHandler: Function}) => {
             <input placeholder='Put image link here...' onChange={imageHandler} value={image} style={{width: '100%', display: 'block', marginBottom: 5}}></input>
             {image ? <img src={image} style={{maxWidth: '100px', maxHeight: '100px'}}></img> : <div></div>}
             <p><b>{formFilled}</b></p>
-            <button disabled={isLoading} onClick={postHandler} style={{background: 'black', color: 'lime', borderRadius: '45%', minWidth: 50}}>Post</button>
+            <button className="btn btn-outline-secondary" disabled={isLoading} onClick={postHandler} style={{minWidth: 50}}>Post</button>
         </div>
     )
 }

--- a/client/src/components/Stories-components/story.styles.css
+++ b/client/src/components/Stories-components/story.styles.css
@@ -1,5 +1,5 @@
 .card {
-    background: #fff;
+    background: rgb(0, 0, 0);
     transition: .5s;
     border: 0;
     margin-bottom: 30px;
@@ -9,12 +9,12 @@
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 10%);
 }
 .card .body {
-    color: #444;
+    color: rgb(255, 255, 255);
     padding: 20px;
     font-weight: 400;
 }
 .card .header {
-    color: #444;
+    color: rgb(255, 255, 255);
     padding: 20px;
     position: relative;
     box-shadow: none;

--- a/client/src/components/TextToSpeech-components/Voice.component.tsx
+++ b/client/src/components/TextToSpeech-components/Voice.component.tsx
@@ -46,7 +46,7 @@ const Voice = (props:{lang?:string, text:string}) => {
                 <>
                     <button className="btn btn-outline-secondary" disabled={isSpeeking} onClick={play} style={{background: !isSpeeking ? 'black' : 'gray', color: 'red', borderColor: '#6c757d', borderWidth: '1px', borderTopLeftRadius: '45%', borderBottomLeftRadius: '45%', borderTopRightRadius: '0%', borderBottomRightRadius: '0%', minWidth: 43}}>Play</button>
                     <button className="btn btn-outline-secondary" disabled={!isSpeeking} onClick={stop} style={{background: isSpeeking ? 'black' : 'gray', color: 'red', borderColor: '#6c757d', borderWidth: '1px', borderTopRightRadius: '45%', borderBottomRightRadius: '45%', borderTopLeftRadius: '0%', borderBottomLeftRadius: '0%', minWidth: 45}}>Stop</button>
-                    <select onChange={select} style={{display: 'table-cell', verticalAlign: 'middle', marginLeft: 5, marginRight: 5}}>
+                    <select onChange={select} style={{display: 'table-cell', verticalAlign: 'middle', marginLeft: 5, marginRight: 5, background: 'black', minHeight: '1.5em', borderWidth: 1, borderColor: '#6c757d'}}>
                         {voices.map(((voice:any, index:number) => {
                            return <option value={voice.name} key={index}>{voice.name}</option>
                         }))}

--- a/client/src/components/TextToSpeech-components/Voice.component.tsx
+++ b/client/src/components/TextToSpeech-components/Voice.component.tsx
@@ -44,9 +44,9 @@ const Voice = (props:{lang?:string, text:string}) => {
         <div id="Voice_Component" style={{display: 'inline-block'}}>
             { supported &&
                 <>
-                    <button disabled={isSpeeking} onClick={play} style={{borderTopLeftRadius: '45%', borderBottomLeftRadius: '45%', minWidth: 43}}>Play</button>
-                    <button disabled={!isSpeeking} onClick={stop} style={{borderTopRightRadius: '45%', borderBottomRightRadius: '45%', minWidth: 45}}>Stop</button>
-                    <select onChange={select} style={{marginLeft: 5, marginRight: 5}}>
+                    <button className="btn btn-outline-secondary" disabled={isSpeeking} onClick={play} style={{background: !isSpeeking ? 'black' : 'gray', color: 'red', borderColor: '#6c757d', borderWidth: '1px', borderTopLeftRadius: '45%', borderBottomLeftRadius: '45%', borderTopRightRadius: '0%', borderBottomRightRadius: '0%', minWidth: 43}}>Play</button>
+                    <button className="btn btn-outline-secondary" disabled={!isSpeeking} onClick={stop} style={{background: isSpeeking ? 'black' : 'gray', color: 'red', borderColor: '#6c757d', borderWidth: '1px', borderTopRightRadius: '45%', borderBottomRightRadius: '45%', borderTopLeftRadius: '0%', borderBottomLeftRadius: '0%', minWidth: 45}}>Stop</button>
+                    <select onChange={select} style={{display: 'table-cell', verticalAlign: 'middle', marginLeft: 5, marginRight: 5}}>
                         {voices.map(((voice:any, index:number) => {
                            return <option value={voice.name} key={index}>{voice.name}</option>
                         }))}

--- a/client/src/routes/stories/stories.component.tsx
+++ b/client/src/routes/stories/stories.component.tsx
@@ -4,7 +4,7 @@ import StoriesPage from '../../components/Stories-components/Stories';
 
 const Stories = () => (
   <div className="container">
-    <h1>Horror Stories</h1>
+    <h1 style={{fontSize: '2.5em', color: 'white'}}>Horror Stories</h1>
     <StoriesPage/>
   </div>
 );


### PR DESCRIPTION
Costumes:
- Fixed button layout for the third time
- Fixed issue where clicking men's/women's costumes button allowed switching regardless of selection

Stories:
- Fixed buttons to match general styling of website
- Adjusted Story Cards when on storylist
- Fixed issue where Clicking title redirected to non-existent endpoint
- Users can now click on image and go to storyDisplay
- Fixed editing section issue where text areas overlapped
- Fixed editing section issue where maximum limit messages blended in with background
- Fixed issue in writing stories where input text blended in with background

Text-To-Speech(Voice):
- Fixed buttons issue where they were invisible save for text on button
- Fixed select bar to be better visible and match general coloration of NuFright